### PR TITLE
Add unit tests for FieldFactory helper methods #HSFDPMUW

### DIFF
--- a/jablib/src/test/java/org/jabref/model/entry/field/FieldFactoryTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/field/FieldFactoryTest.java
@@ -1,6 +1,7 @@
 package org.jabref.model.entry.field;
 
 import java.util.stream.Stream;
+import java.util.Collections;
 
 import org.jabref.model.entry.types.BiblatexApaEntryType;
 
@@ -11,6 +12,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 class FieldFactoryTest {
     @Test
@@ -50,3 +52,48 @@ class FieldFactoryTest {
         assertEquals(BiblatexApaField.ARTICLE, FieldFactory.parseField(BiblatexApaEntryType.Constitution, "article"));
     }
 }
+
+public class FieldFactoryTest {
+
+    @Test
+    void isNotEmptyReturnsFalseForNullOrBlank() {
+        assertFalse(FieldFactory.isNotEmpty(null));
+        assertFalse(FieldFactory.isNotEmpty(""));
+        assertFalse(FieldFactory.isNotEmpty("   "));
+    }
+
+    @Test
+    void isNotEmptyReturnsTrueForNonBlank() {
+        assertTrue(FieldFactory.isNotEmpty("author"));
+        assertTrue(FieldFactory.isNotEmpty("  editor "));
+    }
+
+    @Test
+    void matchesFieldPatternAcceptsValidNames() {
+        assertTrue(FieldFactory.matchesFieldPattern("title"));
+        assertTrue(FieldFactory.matchesFieldPattern("field1"));
+        assertTrue(FieldFactory.matchesFieldPattern("a-b:c"));
+    }
+
+    @Test
+    void matchesFieldPatternRejectsInvalidNames() {
+        assertFalse(FieldFactory.matchesFieldPattern("1title"));
+        assertFalse(FieldFactory.matchesFieldPattern("-field"));
+        assertFalse(FieldFactory.matchesFieldPattern("with space"));
+    }
+
+    @Test
+    void parseOrFieldsReturnsEmptyForBlankInput() {
+        OrFields empty = FieldFactory.parseOrFields("  ");
+        assertEquals(Collections.emptySet(), empty.getFields());
+    }
+
+    @Test
+    void serializeAndParseAreInverseOperations() {
+        String input = "author/editor/unknownField";
+        OrFields fields = FieldFactory.parseOrFields(input);
+        String serialized = FieldFactory.serializeOrFields(fields);
+        assertEquals(input, serialized);
+    }
+}
+


### PR DESCRIPTION
This PR introduces a new test class FieldFactoryTest in jablib that validates the behavior of helper methods: isNotEmpty, matchesFieldPattern, parseOrFields for blank input, and the round-trip of serializeOrFields ↔ parseOrFields. Improves code coverage and guards our recent refactorings. #HSFDPMUW

Closes _____
<!-- LINK THE ISSUE WITH THE "Closes" KEYWORD. Example: Closes https://github.com/JabRef/jabref/issues/13109 OR Closes #13109 -->

<!-- In about one to three sentences, describe the changes you have made: what, where, why, ... (REPLACE THIS LINE) -->

<!-- NOTE: If your work is not yet complete, please open a draft pull request. In that case, outline your intended next steps. Do you need feedback? Will you continue in parallel? ... -->

### Steps to test

<!-- Describe how reviewers can test this fix/feature. Ideally, think of how you would guide a beginner user of Jabef to try out your change. -->
<!-- You can add screenshots or videos (using Loom - https://www.loom.com or by just adding .mp4 files). -->
<!-- (REPLACE THIS PARAGRAPH) -->

<!-- YOU HAVE TO MODIFY THE ABOVE TEXT FIT YOUR PR. OTHERWISE, YOUR PR WILL BE CLOSED WITHOUT FURTHER COMMENT. -->

### Mandatory checks

<!--
Go through the checklist below. It is mandatory, even for a draft pull request.

Keep ALL the items. Replace the dots inside [.] and mark them as follows: 
[x] done 
[ ] TODO (yet to be done)
[/] not applicable
-->

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [.] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [.] Tests created for changes (if applicable)
- [.] Manually tested changed features in running JabRef (always required)
- [.] Screenshots added in PR description (if change is visible to the user)
- [.] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [.] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
