### PR TITLE
Add null check to AiNamingUtils.getDisplayName(AiProvider) (#HSFDPMUW)

### DIFF
--- a/jablib/src/main/java/org/jabref/logic/ai/AiNamingUtils.java
+++ b/jablib/src/main/java/org/jabref/logic/ai/AiNamingUtils.java
@@ -14,17 +14,17 @@ public final class AiNamingUtils {
     }
 
     public static String getDisplayName(AiProvider provider) {
-        return switch (provider) {
-            case OPEN_AI ->
-                    Localization.lang("OpenAI (or API compatible)");
-            case MISTRAL_AI ->
-                    "Mistral AI";
-            case GEMINI ->
-                    "Gemini";
-            case HUGGING_FACE ->
-                    "Hugging Face";
-        };
+    if (provider == null) {
+        return Localization.lang("Unknown Provider (#HSFDPMUW)");
     }
+    return switch (provider) {
+        case OPEN_AI -> Localization.lang("OpenAI (or API compatible)");
+        case MISTRAL_AI -> "Mistral AI";
+        case GEMINI -> "Gemini";
+        case HUGGING_FACE -> "Hugging Face";
+    };
+}
+
 
     public static String getDisplayName(ResponseEngineKind kind) {
         return switch (kind) {


### PR DESCRIPTION
This PR adds a null check to AiNamingUtils.getDisplayName(AiProvider) to prevent potential NullPointerExceptions and improve robustness.

Tag: #HSFDPMUW
