### PR TITLE
Clarify Java version requirement in CONTRIBUTING.md (#HSFDPMUW)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,7 @@ We favor looking into your code using a draft pull request, because we can then 
 As counterexample, if you provide us with a screenshot of your changes, we cannot run it in our IDE.
 
 ### Requirements on the pull request and code
+Before building JabRef, ensure that Java 21 or newer is installed.
 
 #### Test your code
 


### PR DESCRIPTION
This PR improves the CONTRIBUTING.md by clarifying that JabRef requires Java 21 or newer for development.

Tag: #HSFDPMUW
